### PR TITLE
emit result with formatted EDN; alpha release

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -143,6 +143,36 @@
           "v" {:type :leaf, :by "yeKFqj7rX", :at 1564856112082, :text "j", :id "YqAfqk3HRt"}
          }
         }
+        "yy" {
+         :type :expr, :by "yeKFqj7rX", :at 1573571834811, :id "fWWyo3hmxY"
+         :data {
+          "T" {:type :leaf, :by "yeKFqj7rX", :at 1573571835089, :text "[]", :id "fWWyo3hmxYleaf"}
+          "j" {:type :leaf, :by "yeKFqj7rX", :at 1573571838340, :text "cljs.reader", :id "Ql4iVEmKA"}
+          "r" {:type :leaf, :by "yeKFqj7rX", :at 1573571840295, :text ":refer", :id "u1iIsHesHa"}
+          "v" {
+           :type :expr, :by "yeKFqj7rX", :at 1573571841005, :id "lihqP9gszH"
+           :data {
+            "T" {:type :leaf, :by "yeKFqj7rX", :at 1573571841323, :text "[]", :id "CsEAX_4hxk"}
+            "j" {:type :leaf, :by "yeKFqj7rX", :at 1573571842851, :text "read-string", :id "msDHfSH_c"}
+           }
+          }
+         }
+        }
+        "yyT" {
+         :type :expr, :by "yeKFqj7rX", :at 1573572441099, :id "rLxbzI67p5"
+         :data {
+          "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572441484, :text "[]", :id "rLxbzI67p5leaf"}
+          "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572448028, :text "favored-edn.core", :id "NxcL_BbKg"}
+          "r" {:type :leaf, :by "yeKFqj7rX", :at 1573572449721, :text ":refer", :id "ArJ9uWEo-p"}
+          "v" {
+           :type :expr, :by "yeKFqj7rX", :at 1573572449957, :id "SnzArkWcue"
+           :data {
+            "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572450137, :text "[]", :id "41Z_rYftuh"}
+            "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572453137, :text "write-edn", :id "Wd9ra-fIc"}
+           }
+          }
+         }
+        }
        }
       }
       "v" {
@@ -1362,6 +1392,118 @@
        }
       }
      }
+     "replace-dep" {
+      :type :expr, :by "yeKFqj7rX", :at 1573572151817, :id "vsK7PjzIEb"
+      :data {
+       "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572151817, :text "defn", :id "xoFSUru3NZ"}
+       "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572151817, :text "replace-dep", :id "g7PiaJ-Y3G"}
+       "r" {
+        :type :expr, :by "yeKFqj7rX", :at 1573572151817, :id "aHEJTbAFH2"
+        :data {
+         "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572151817, :text "dep", :id "Pxz7TDYYxI"}
+         "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572151817, :text "new-versions", :id "qsfw0yEleN"}
+        }
+       }
+       "v" {
+        :type :expr, :by "yeKFqj7rX", :at 1573572159275, :id "krb003vp_"
+        :data {
+         "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572159787, :text "if", :id "krb003vp_leaf"}
+         "j" {
+          :type :expr, :by "yeKFqj7rX", :at 1573572161331, :id "WUYywoqYui"
+          :data {
+           "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572162053, :text "empty?", :id "0YkcIOe-5O"}
+           "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572164451, :text "new-versions", :id "nY817kr8Lq"}
+          }
+         }
+         "n" {:type :leaf, :by "yeKFqj7rX", :at 1573572558735, :text "dep", :id "nseKeKThL"}
+         "r" {
+          :type :expr, :by "yeKFqj7rX", :at 1573572164971, :id "7V5i68r4Av"
+          :data {
+           "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572165367, :text "let", :id "7V5i68r4Avleaf"}
+           "j" {
+            :type :expr, :by "yeKFqj7rX", :at 1573572165590, :id "Lf-0UPhso"
+            :data {
+             "T" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572166017, :id "_L7CAr17YP"
+              :data {
+               "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572168380, :text "cursor", :id "U7ZL-JQOHG"}
+               "j" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572168798, :id "3cBb-L_wyW"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572169932, :text "first", :id "iGh4Hj4W6"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572172238, :text "new-versions", :id "6D63e8SCkU"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "yeKFqj7rX", :at 1573572176997, :id "N7d71TN2M"
+            :data {
+             "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572177560, :text "if", :id "N7d71TN2Mleaf"}
+             "j" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572178064, :id "DFz6VnOkgZ"
+              :data {
+               "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572178360, :text "=", :id "7Q6_pd9Uez"}
+               "j" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572179480, :id "-GkImQcjDk"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572181629, :text "first", :id "13abrkerE"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572721841, :text "dep", :id "xPCFgrKgi"}
+                }
+               }
+               "r" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572194278, :id "GUUV5CJMMQ"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572200445, :text ":pkg", :id "GUUV5CJMMQleaf"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572203054, :text "cursor", :id "IzXPn7BAp"}
+                }
+               }
+              }
+             }
+             "r" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572205192, :id "88ZeWPd5x"
+              :data {
+               "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572216388, :text "[]", :id "88ZeWPd5xleaf"}
+               "j" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572216848, :id "SMOnMnioHV"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572220699, :text ":pkg", :id "UHs2oSoyS"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572222368, :text "cursor", :id "-mtjwtq11"}
+                }
+               }
+               "r" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572223021, :id "31EZRCiSEJ"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572226849, :text ":to", :id "31EZRCiSEJleaf"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572228511, :text "cursor", :id "5QwPojgI__"}
+                }
+               }
+              }
+             }
+             "v" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572284147, :id "Ev3YbKDyyE"
+              :data {
+               "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572419151, :text "recur", :id "6j0Sx7vwX"}
+               "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572286640, :text "dep", :id "ylo9ow1Q5"}
+               "r" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572288118, :id "bX1eyVHNsI"
+                :data {
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572289661, :text "rest", :id "7R-A94FrU"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572291787, :text "new-versions", :id "d1s86zOkWO"}
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
      "replace-numbers" {
       :type :expr, :by "yeKFqj7rX", :at 1560878923244, :id "8iY8keGHv_"
       :data {
@@ -1375,128 +1517,77 @@
         }
        }
        "v" {
-        :type :expr, :by "yeKFqj7rX", :at 1560878929775, :id "bh_ugHIGxk"
+        :type :expr, :by "yeKFqj7rX", :at 1560878936381, :id "q7LFezoqxF"
         :data {
-         "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878930162, :text "if", :id "bh_ugHIGxkleaf"}
+         "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878938256, :text "let", :id "sJ0GF3YA-5"}
          "j" {
-          :type :expr, :by "yeKFqj7rX", :at 1560878930633, :id "DdestlqAp"
+          :type :expr, :by "yeKFqj7rX", :at 1560878938697, :id "l8jpZ-b5b"
           :data {
-           "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878932298, :text "empty?", :id "3IchOg2yJb"}
-           "j" {:type :leaf, :by "yeKFqj7rX", :at 1560878934287, :text "new-versions", :id "HQhXDXaLh"}
-          }
-         }
-         "r" {:type :leaf, :by "yeKFqj7rX", :at 1560878935704, :text "content", :id "tMsjloFRlk"}
-         "v" {
-          :type :expr, :by "yeKFqj7rX", :at 1560878936381, :id "q7LFezoqxF"
-          :data {
-           "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878938256, :text "let", :id "sJ0GF3YA-5"}
-           "j" {
-            :type :expr, :by "yeKFqj7rX", :at 1560878938697, :id "l8jpZ-b5b"
+           "L" {
+            :type :expr, :by "yeKFqj7rX", :at 1573572038743, :id "Tv7Yyv6_f"
             :data {
-             "T" {
-              :type :expr, :by "yeKFqj7rX", :at 1560878939185, :id "FlsKQfT7es"
+             "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572040273, :text "new-config", :id "Tv7Yyv6_fleaf"}
+             "j" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572936924, :id "U4pw5R3pJC"
               :data {
-               "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878943823, :text "rule", :id "qYm5NhbtG9"}
-               "j" {
-                :type :expr, :by "yeKFqj7rX", :at 1560878946103, :id "qRICFqJKEg"
+               "D" {:type :leaf, :by "yeKFqj7rX", :at 1573572938019, :text "->", :id "NLPQ1NN4Zg"}
+               "L" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572974697, :id "5N17I0F2hr"
                 :data {
-                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878947738, :text "first", :id "tLYpMZXcV"}
-                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1560878950553, :text "new-versions", :id "qFh47ZoP0o"}
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572974697, :text "read-string", :id "yvZec6pcD9"}
+                 "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572974697, :text "content", :id "YW7VZgd_sE"}
                 }
                }
-              }
-             }
-             "j" {
-              :type :expr, :by "yeKFqj7rX", :at 1560878974503, :id "51o3MYD4jm"
-              :data {
-               "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878975693, :text "new-content", :id "51o3MYD4jmleaf"}
-               "j" {
-                :type :expr, :by "yeKFqj7rX", :at 1560880052391, :id "Sb_nt9cRju"
+               "T" {
+                :type :expr, :by "yeKFqj7rX", :at 1573572040564, :id "fCP2v46NV"
                 :data {
-                 "D" {:type :leaf, :by "yeKFqj7rX", :at 1560880053099, :text "let", :id "JTacb6on5"}
-                 "L" {
-                  :type :expr, :by "yeKFqj7rX", :at 1560880053580, :id "MqEoc12Is"
+                 "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572041196, :text "update", :id "_5mMAc-HXS"}
+                 "r" {:type :leaf, :by "yeKFqj7rX", :at 1573572052708, :text ":dependencies", :id "RwuzLgupQZ"}
+                 "v" {
+                  :type :expr, :by "yeKFqj7rX", :at 1573572053812, :id "o6Y5yafm3p"
                   :data {
-                   "T" {
-                    :type :expr, :by "yeKFqj7rX", :at 1560880053732, :id "wn2nR37lbP"
+                   "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572054103, :text "fn", :id "4IOqyaLZ7"}
+                   "j" {
+                    :type :expr, :by "yeKFqj7rX", :at 1573572054634, :id "3a8DJBPgw"
                     :data {
-                     "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880055073, :text "pattern", :id "CF8t3H6gon"}
-                     "j" {
-                      :type :expr, :by "yeKFqj7rX", :at 1560880055594, :id "hNLsD5F-rp"
-                      :data {
-                       "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "re-pattern", :id "99XfTSV0p1"}
-                       "j" {
-                        :type :expr, :by "yeKFqj7rX", :at 1560880055594, :id "eqg0mYasN0"
-                        :data {
-                         "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "str", :id "BldG0l2JTI"}
-                         "j" {
-                          :type :expr, :by "yeKFqj7rX", :at 1560880055594, :id "Z94E-jkxpa"
-                          :data {
-                           "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text ":pkg", :id "PTw9vpshFr"}
-                           "j" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "rule", :id "hq3VeqcO1O"}
-                          }
-                         }
-                         "r" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "\"\\s+", :id "_sz0XvgqTB"}
-                         "v" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "\"\"", :id "XY5Q_-qhM3"}
-                         "x" {
-                          :type :expr, :by "yeKFqj7rX", :at 1560881237216, :id "-0DCPkDG9"
-                          :data {
-                           "D" {:type :leaf, :by "yeKFqj7rX", :at 1560881240559, :text "string/replace", :id "vgLAWzR0v"}
-                           "T" {
-                            :type :expr, :by "yeKFqj7rX", :at 1560880055594, :id "lxSf2zGDeB"
-                            :data {
-                             "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text ":from", :id "kWEcuIlVcm"}
-                             "j" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "rule", :id "7f1NZtuaRu"}
-                            }
-                           }
-                           "j" {:type :leaf, :by "yeKFqj7rX", :at 1560881243774, :text "\".", :id "boLOUlAKHy"}
-                           "r" {:type :leaf, :by "yeKFqj7rX", :at 1560881248740, :text "\"\\.", :id "dYvgprkguk"}
-                          }
-                         }
-                         "y" {:type :leaf, :by "yeKFqj7rX", :at 1560880055594, :text "\"\"", :id "1_7vA2a_cg"}
-                        }
-                       }
-                      }
-                     }
+                     "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572056472, :text "deps", :id "Xn1IQ2i_Tc"}
                     }
                    }
-                  }
-                 }
-                 "T" {
-                  :type :expr, :by "yeKFqj7rX", :at 1560879941952, :id "oMig3JoK8"
-                  :data {
-                   "T" {:type :leaf, :by "yeKFqj7rX", :at 1560879949023, :text "string/replace", :id "oMig3JoK8leaf"}
-                   "b" {:type :leaf, :by "yeKFqj7rX", :at 1560879985495, :text "content", :id "xx8rJo5I74"}
-                   "j" {:type :leaf, :by "yeKFqj7rX", :at 1560880059782, :text "pattern", :id "-ySn2rlDn"}
                    "r" {
-                    :type :expr, :by "yeKFqj7rX", :at 1560879986881, :id "2Wjwi76Im"
+                    :type :expr, :by "yeKFqj7rX", :at 1573572092688, :id "yQPh9LPuV"
                     :data {
-                     "T" {:type :leaf, :by "yeKFqj7rX", :at 1560879987905, :text "fn", :id "2Wjwi76Imleaf"}
-                     "j" {
-                      :type :expr, :by "yeKFqj7rX", :at 1560879988307, :id "hj1saFaC4h"
+                     "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572096064, :text "->>", :id "yQPh9LPuVleaf"}
+                     "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572097528, :text "deps", :id "ud13TMDcu2"}
+                     "r" {
+                      :type :expr, :by "yeKFqj7rX", :at 1573572098059, :id "SusLoz7Dfd"
                       :data {
-                       "T" {:type :leaf, :by "yeKFqj7rX", :at 1560879988928, :text "piece", :id "uSUu4fNu2S"}
+                       "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572098550, :text "map", :id "jDruq_BP6y"}
+                       "j" {
+                        :type :expr, :by "yeKFqj7rX", :at 1573572102850, :id "SV-nYZr2a-"
+                        :data {
+                         "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572103198, :text "fn", :id "OybQu33br"}
+                         "j" {
+                          :type :expr, :by "yeKFqj7rX", :at 1573572103451, :id "4iFxGkTbBG"
+                          :data {
+                           "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572105288, :text "dep", :id "rFOKJX4MyJ"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "yeKFqj7rX", :at 1573572930214, :id "cNZOf9wGYw"
+                          :data {
+                           "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572930214, :text "replace-dep", :id "PRKbm3N6fw"}
+                           "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572930214, :text "dep", :id "-22cOmlqDq"}
+                           "r" {:type :leaf, :by "yeKFqj7rX", :at 1573572930214, :text "new-versions", :id "MALGAh1oRP"}
+                          }
+                         }
+                        }
+                       }
                       }
                      }
                      "v" {
-                      :type :expr, :by "yeKFqj7rX", :at 1560880240525, :id "xRPP63Dj9"
+                      :type :expr, :by "yeKFqj7rX", :at 1573572099471, :id "F_quWAu7CO"
                       :data {
-                       "D" {:type :leaf, :by "yeKFqj7rX", :at 1560880243788, :text "string/replace", :id "-wcbbP_Wwc"}
-                       "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880013693, :text "piece", :id "yJLBjOcLC"}
-                       "j" {
-                        :type :expr, :by "yeKFqj7rX", :at 1560880244925, :id "Brz2670SQ"
-                        :data {
-                         "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880246038, :text ":from", :id "1TxOcTuahB"}
-                         "j" {:type :leaf, :by "yeKFqj7rX", :at 1560880247287, :text "rule", :id "5QcL9Fvl9"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "yeKFqj7rX", :at 1560880247700, :id "5u9MUQI1kQ"
-                        :data {
-                         "T" {:type :leaf, :by "yeKFqj7rX", :at 1560880248365, :text ":to", :id "5u9MUQI1kQleaf"}
-                         "j" {:type :leaf, :by "yeKFqj7rX", :at 1560880249524, :text "rule", :id "TpvrTDgmP"}
-                        }
-                       }
+                       "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572100982, :text "vec", :id "F_quWAu7COleaf"}
                       }
                      }
                     }
@@ -1509,16 +1600,22 @@
              }
             }
            }
+          }
+         }
+         "v" {
+          :type :expr, :by "yeKFqj7rX", :at 1573572308632, :id "qyIBiKgqD"
+          :data {
+           "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572310422, :text "write-edn", :id "qyIBiKgqDleaf"}
+           "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572311099, :text "new-config", :id "ZMeSUR0zD"}
            "r" {
-            :type :expr, :by "yeKFqj7rX", :at 1560878952624, :id "A4-lD_ORb"
+            :type :expr, :by "yeKFqj7rX", :at 1573572319171, :id "hz-D6w0dZ"
             :data {
-             "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878954236, :text "recur", :id "A4-lD_ORbleaf"}
-             "j" {:type :leaf, :by "yeKFqj7rX", :at 1560878958694, :text "new-content", :id "Pe0hLPz_K"}
-             "r" {
-              :type :expr, :by "yeKFqj7rX", :at 1560878962643, :id "RSzkNiRME"
+             "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572319599, :text "{}", :id "hOYbS8Sln"}
+             "j" {
+              :type :expr, :by "yeKFqj7rX", :at 1573572320212, :id "dznl8crNam"
               :data {
-               "T" {:type :leaf, :by "yeKFqj7rX", :at 1560878964652, :text "rest", :id "IJ6IgOeEz"}
-               "j" {:type :leaf, :by "yeKFqj7rX", :at 1560878972655, :text "new-versions", :id "5XxtI0ITP"}
+               "T" {:type :leaf, :by "yeKFqj7rX", :at 1573572321081, :text ":indent", :id "-8uieg9C09"}
+               "j" {:type :leaf, :by "yeKFqj7rX", :at 1573572321643, :text "2", :id "22ifZ90RK6"}
               }
              }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvc-works/clojars-outdated",
-  "version": "0.1.4",
+  "version": "0.1.5-a1",
   "scripts": {
     "watch": "yarn shadow-cljs watch app",
     "prepare": "yarn build",
@@ -14,13 +14,13 @@
   "author": "jiyinyiyong <jiyinyiyong@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "shadow-cljs": "^2.8.59",
-    "source-map-support": "^0.5.13",
-    "ws": "^7.1.2"
+    "shadow-cljs": "^2.8.69",
+    "source-map-support": "^0.5.16",
+    "ws": "^7.2.0"
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "chalk": "^2.4.2",
+    "chalk": "^3.0.0",
     "latest-version": "^5.1.0"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,14 +1,25 @@
-{:source-paths ["src"]
- :repositories {"central" {:url "https://maven.aliyun.com/nexus/content/groups/public/"}
-                "clojars" {:url "https://mirrors.ustc.edu.cn/clojars/"}}
- :dependencies [[mvc-works/chan-utils       "0.1.0"]
-                [cljs-node-io               "1.1.2"]
-                [medley                     "1.2.0"]
-                [appliedscience/js-interop  "0.1.20"]
-                [org.clojure/core.incubator "0.1.4"]]
- :builds {:app {:target :node-script
-                :output-to "target/server.js"
-                :main app.main/main!
-                :devtools {:after-load app.main/reload!}
-                :release {:output-to "dist/server.js"
-                          :compiler-options {:optimizations :simple}}}}}
+{
+  :source-paths ["src"]
+  :repositories {
+    "central" {:url "https://maven.aliyun.com/nexus/content/groups/public/"}
+    "clojars" {:url "https://mirrors.ustc.edu.cn/clojars/"}
+  }
+  :dependencies [
+    [mvc-works/chan-utils "0.1.1"]
+    [cljs-node-io "1.1.2"]
+    [medley "1.2.0"]
+    [cirru/favored-edn "0.1.2"]
+    [appliedscience/js-interop "0.1.21"]
+    [org.clojure/core.incubator "0.1.4"]
+  ]
+  :builds {
+    :app {
+      :target :node-script, :output-to "target/server.js", :main app.main/main!
+      :devtools {:after-load app.main/reload!}
+      :release {
+        :output-to "dist/server.js"
+        :compiler-options {:optimizations :simple}
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,17 +9,23 @@
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.npm.taobao.org/@szmarczak/http-timer/download/@szmarczak/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  resolved "https://registry.npm.taobao.org/@szmarczak/http-timer/download/@szmarczak/http-timer-1.1.2.tgz?cache=0&sync_timestamp=1572713077034&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40szmarczak%2Fhttp-timer%2Fdownload%2F%40szmarczak%2Fhttp-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
   integrity sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=
   dependencies:
     defer-to-connect "^1.0.1"
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&sync_timestamp=1566430679283&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npm.taobao.org/@types/color-name/download/@types/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=
+
+ansi-styles@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.2.0.tgz?cache=0&sync_timestamp=1573557674483&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
+  integrity sha1-VoHw3PeuWICnhB2IMcRyTtnMAXI=
   dependencies:
-    color-convert "^1.9.0"
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -32,7 +38,7 @@ asn1.js@^4.0.0:
 
 assert@^1.1.1:
   version "1.5.0"
-  resolved "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  resolved "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fassert%2Fdownload%2Fassert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
   integrity sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=
   dependencies:
     object-assign "^4.1.1"
@@ -136,9 +142,9 @@ buffer-xor@^1.0.3:
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
-  version "4.9.1"
-  resolved "https://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz?cache=0&sync_timestamp=1568256965052&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbuffer%2Fdownload%2Fbuffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  version "4.9.2"
+  resolved "https://registry.npm.taobao.org/buffer/download/buffer-4.9.2.tgz?cache=0&sync_timestamp=1573257183822&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbuffer%2Fdownload%2Fbuffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -151,7 +157,7 @@ builtin-status-codes@^3.0.0:
 
 cacheable-request@^6.0.0:
   version "6.1.0"
-  resolved "https://registry.npm.taobao.org/cacheable-request/download/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  resolved "https://registry.npm.taobao.org/cacheable-request/download/cacheable-request-6.1.0.tgz?cache=0&sync_timestamp=1570667085178&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcacheable-request%2Fdownload%2Fcacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
   integrity sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=
   dependencies:
     clone-response "^1.0.2"
@@ -162,14 +168,13 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npm.taobao.org/chalk/download/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=
   dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -186,24 +191,22 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=
   dependencies:
-    color-name "1.1.3"
+    color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npm.taobao.org/color-name/download/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=
 
 console-browserify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
-  integrity sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
-  dependencies:
-    date-now "^0.1.4"
+  version "1.2.0"
+  resolved "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
+  integrity sha1-ZwY871fOts9Jk6KrOlWECujEkzY=
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -263,11 +266,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-date-now@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.npm.taobao.org/date-now/download/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
-  integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
-
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -288,9 +286,9 @@ deep-extend@^0.6.0:
   integrity sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=
 
 defer-to-connect@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npm.taobao.org/defer-to-connect/download/defer-to-connect-1.0.2.tgz#4bae758a314b034ae33902b5aac25a8dd6a8633e"
-  integrity sha1-S651ijFLA0rjOQK1qsJajdaoYz4=
+  version "1.1.0"
+  resolved "https://registry.npm.taobao.org/defer-to-connect/download/defer-to-connect-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefer-to-connect%2Fdownload%2Fdefer-to-connect-1.1.0.tgz#b41bd7efa8508cef13f8456975f7a278c72833fd"
+  integrity sha1-tBvX76hQjO8T+EVpdfeieMcoM/0=
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -339,11 +337,6 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npm.taobao.org/events/download/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -359,7 +352,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
 
 follow-redirects@1.5.10:
   version "1.5.10"
-  resolved "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.5.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  resolved "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
   integrity sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=
   dependencies:
     debug "=3.1.0"
@@ -380,7 +373,7 @@ get-stream@^5.1.0:
 
 got@^9.6.0:
   version "9.6.0"
-  resolved "https://registry.npm.taobao.org/got/download/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  resolved "https://registry.npm.taobao.org/got/download/got-9.6.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgot%2Fdownload%2Fgot-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
   integrity sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=
   dependencies:
     "@sindresorhus/is" "^0.14.0"
@@ -395,10 +388,10 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -442,17 +435,17 @@ ieee754@^1.1.4:
 
 inherits@2.0.1:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
 
 ini@~1.3.0:
@@ -560,7 +553,7 @@ ms@2.0.0:
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
-  resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnode-libs-browser%2Fdownload%2Fnode-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=
   dependencies:
     assert "^1.1.1"
@@ -589,7 +582,7 @@ node-libs-browser@^2.0.0:
 
 normalize-url@^4.1.0:
   version "4.5.0"
-  resolved "https://registry.npm.taobao.org/normalize-url/download/normalize-url-4.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnormalize-url%2Fdownload%2Fnormalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  resolved "https://registry.npm.taobao.org/normalize-url/download/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=
 
 object-assign@^4.1.1:
@@ -616,7 +609,7 @@ p-cancelable@^1.0.0:
 
 package-json@^6.3.0:
   version "6.5.0"
-  resolved "https://registry.npm.taobao.org/package-json/download/package-json-6.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpackage-json%2Fdownload%2Fpackage-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
+  resolved "https://registry.npm.taobao.org/package-json/download/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
   integrity sha1-b+7ayjXnVyWHbQsOZJdGl/7RRbA=
   dependencies:
     got "^9.6.0"
@@ -772,7 +765,7 @@ registry-url@^5.0.0:
 
 responselike@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/responselike/download/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  resolved "https://registry.npm.taobao.org/responselike/download/responselike-1.0.2.tgz?cache=0&sync_timestamp=1570573217730&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresponselike%2Fdownload%2Fresponselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
@@ -818,10 +811,10 @@ shadow-cljs-jar@1.3.1:
   resolved "https://registry.npm.taobao.org/shadow-cljs-jar/download/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
   integrity sha1-pfirdmS0DhE0WDfkxrzo4KybLMM=
 
-shadow-cljs@^2.8.59:
-  version "2.8.59"
-  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.8.59.tgz#41de7c44bdf8e835f3c7dc19e415732e6cada844"
-  integrity sha1-Qd58RL346DXzx9wZ5BVzLmytqEQ=
+shadow-cljs@^2.8.69:
+  version "2.8.69"
+  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.8.69.tgz#a646926ce0ba2b0b0f1086925a1048fdd69ebb08"
+  integrity sha1-pkaSbOC6KwsPEIaSWhBI/daeuwg=
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"
@@ -838,10 +831,10 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.13:
-  version "0.5.13"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
-  integrity sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=
+source-map-support@^0.5.16:
+  version "0.5.16"
+  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -894,12 +887,12 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.npm.taobao.org/strip-json-comments/download/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npm.taobao.org/supports-color/download/supports-color-7.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=
   dependencies:
-    has-flag "^3.0.0"
+    has-flag "^4.0.0"
 
 timers-browserify@^2.0.4:
   version "2.0.11"
@@ -950,22 +943,22 @@ util-deprecate@~1.0.1:
 
 util@0.10.3:
   version "0.10.3"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz?cache=0&sync_timestamp=1562337713422&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 util@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz?cache=0&sync_timestamp=1562337713422&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
   integrity sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=
   dependencies:
     inherits "2.0.3"
 
 vm-browserify@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
-  integrity sha1-vXbWojMj4sqP+hICjcBFWcdfkBk=
+  version "1.1.2"
+  resolved "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.2.tgz?cache=0&sync_timestamp=1572870772154&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvm-browserify%2Fdownload%2Fvm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
 
 which@^1.3.1:
   version "1.3.1"
@@ -988,10 +981,10 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-7.1.2.tgz#c672d1629de8bb27a9699eb599be47aeeedd8f73"
-  integrity sha1-xnLRYp3ouyepaZ61mb5Hru7dj3M=
+ws@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npm.taobao.org/ws/download/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
+  integrity sha1-Qi7ajAKktdundEumbuu9hLzvDsc=
   dependencies:
     async-limiter "^1.0.0"
 


### PR DESCRIPTION
`shadow-cljs.edn` now is replaced based on data structure rather than string replacement.

Output now emitted in code formatted with `flavored-edn` in 2 spaces indentation. Would be more friendly for Git.
